### PR TITLE
Fix DDEV install: run as ddev user, not root

### DIFF
--- a/packages/trafic-agent/src/setup/ddev.ts
+++ b/packages/trafic-agent/src/setup/ddev.ts
@@ -14,10 +14,14 @@ export function installDdev(): void {
   }
 
   // Install DDEV using the official install script
-  info("Installing DDEV...");
+  // Must run as ddev user (not root) per DDEV requirements
+  info("Installing DDEV as user 'ddev'...");
   exec(
-    "curl -fsSL https://ddev.com/install.sh | bash -s -- --version latest",
+    "su - ddev -c 'curl -fsSL https://ddev.com/install.sh | bash -s -- --version latest'",
   );
+
+  // Symlink ddev binary to /usr/local/bin so it's available system-wide
+  exec("ln -sf /home/ddev/.ddev/bin/ddev /usr/local/bin/ddev");
 
   success("DDEV installed");
 }


### PR DESCRIPTION
## Problem

DDEV install script refuses to run as root:
```
This script must NOT be run with sudo/root. Please re-run without sudo.
```

## Solution

- Run DDEV install as the `ddev` user
- Symlink the binary to `/usr/local/bin` for system-wide access

## Testing

Tested on Hetzner cx23 server with Ubuntu 24.04.