### PR TITLE
Fix DDEV setup: don't start router without a project

### DIFF
--- a/packages/trafic-agent/src/setup/ddev.ts
+++ b/packages/trafic-agent/src/setup/ddev.ts
@@ -92,11 +92,7 @@ export function configureDdev(tld: string, email?: string): void {
   // Disable instrumentation (telemetry)
   exec(ddevCmd("ddev config global --instrumentation-opt-in=false"));
 
-  // Start the router
-  exec(ddevCmd("ddev poweroff || true"));
-  exec(ddevCmd("ddev start"));
-
-  success("DDEV router started");
+  success("DDEV global settings configured");
 }
 
 /**


### PR DESCRIPTION
## Problem

Setup was calling `ddev start` which fails without a project:
```
Failed to start project(s): could not find a project in /home/ddev
```

## Solution

Just configure global settings. The router starts automatically when the first project is deployed.