### PR TITLE
fix: Traefik entry point middleware + basic_auth parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, develop, "feature/**"]
+    branches: [main, develop, "feature/**", "fix/**"]
   pull_request:
     branches: [main, develop]
 

--- a/packages/trafic-agent/src/setup/ddev.ts
+++ b/packages/trafic-agent/src/setup/ddev.ts
@@ -170,16 +170,20 @@ export function getDockerGatewayIp(): string {
 export function configureTraefik(): void {
   step("Configure Traefik for forward auth");
 
-  // Create custom Traefik config directory
-  exec("mkdir -p /home/ddev/.ddev/traefik", { silent: true });
+  // Create custom Traefik config directories
+  exec("mkdir -p /home/ddev/.ddev/traefik/custom-global-config", { silent: true });
   exec("chown -R ddev:ddev /home/ddev/.ddev", { silent: true });
 
   // Use the Docker bridge gateway IP instead of host.docker.internal —
   // the latter is not available on Linux without extra Docker configuration.
   const gatewayIp = getDockerGatewayIp();
 
-  // Static configuration for Trafic middleware
-  const staticConfig = `# Trafic: Forward auth middleware
+  // Dynamic configuration: defines the trafic-auth and trafic-errors middlewares
+  // and the trafic-service backend pointing at the agent.
+  // Written to:
+  //   - custom-global-config/ — picked up by DDEV 1.25+ (survives config dir purge on restart)
+  //   - traefik root — also watched by older DDEV versions
+  const dynamicConfig = `# Trafic: Forward auth middleware definition
 http:
   middlewares:
     trafic-auth:
@@ -203,25 +207,30 @@ http:
           - url: "http://${gatewayIp}:9876"
 `;
 
-  writeFileSync("/home/ddev/.ddev/traefik/trafic.yaml", staticConfig);
+  writeFileSync("/home/ddev/.ddev/traefik/trafic.yaml", dynamicConfig);
   exec("chown ddev:ddev /home/ddev/.ddev/traefik/trafic.yaml", { silent: true });
+  writeFileSync("/home/ddev/.ddev/traefik/custom-global-config/trafic.yaml", dynamicConfig);
+  exec("chown ddev:ddev /home/ddev/.ddev/traefik/custom-global-config/trafic.yaml", { silent: true });
 
-  // Create default router config that applies middleware to all projects
-  const routerConfig = `# Trafic: Default router configuration
-# This file makes all DDEV projects use the Trafic auth middleware
-http:
-  routers:
-    trafic-catch-all:
-      rule: "HostRegexp(\`.+\`)"
-      priority: 1
+  // Static configuration: attaches trafic-auth and trafic-errors to the
+  // http-80 and http-443 entry points so every request goes through auth —
+  // regardless of which project router handles it.
+  // DDEV merges all static_config.*.yaml files into .static_config.yaml on start.
+  const staticConfig = `entryPoints:
+  http-80:
+    http:
       middlewares:
-        - trafic-auth
-        - trafic-errors
-      service: api@internal
+        - trafic-auth@file
+        - trafic-errors@file
+  http-443:
+    http:
+      middlewares:
+        - trafic-auth@file
+        - trafic-errors@file
 `;
 
-  writeFileSync("/home/ddev/.ddev/traefik/dynamic.yaml", routerConfig);
-  exec("chown ddev:ddev /home/ddev/.ddev/traefik/dynamic.yaml", { silent: true });
+  writeFileSync("/home/ddev/.ddev/traefik/static_config.trafic.yaml", staticConfig);
+  exec("chown ddev:ddev /home/ddev/.ddev/traefik/static_config.trafic.yaml", { silent: true });
 
   success("Traefik configured with Trafic middleware");
 }

--- a/packages/trafic-agent/src/setup/migrations/0008__traefik_entrypoint_middleware.ts
+++ b/packages/trafic-agent/src/setup/migrations/0008__traefik_entrypoint_middleware.ts
@@ -1,0 +1,90 @@
+import { writeFileSync, rmSync, existsSync } from "node:fs";
+import { exec } from "../steps.js";
+import { getDockerGatewayIp } from "../ddev.js";
+import type { Migration } from "../types.js";
+
+/**
+ * Migration 0008: Switch Traefik from catch-all router to entry point middleware.
+ *
+ * The previous approach used a low-priority catch-all router (priority=1) with
+ * trafic-auth middleware in dynamic.yaml. This failed because DDEV's project-specific
+ * routers always win — they have higher priority and no trafic-auth middleware.
+ *
+ * The correct approach (from the previous trafic v1 with DDEV 1.24) is to attach
+ * the middleware at the entry point level via a static_config.*.yaml file that DDEV
+ * merges into .static_config.yaml on every start. This ensures every request on
+ * http-80 and http-443 passes through auth regardless of which router handles it.
+ *
+ * Changes:
+ * - Write static_config.trafic.yaml: attaches trafic-auth@file + trafic-errors@file
+ *   to the http-80 and http-443 entry points
+ * - Write trafic.yaml to custom-global-config/ (survives DDEV 1.25+ config purge)
+ * - Remove the old dynamic.yaml catch-all router
+ */
+export const migration0008TraefikEntrypointMiddleware: Migration = {
+  id: "0008__traefik_entrypoint_middleware",
+  description:
+    "Switch Traefik auth from catch-all router to entry point middleware",
+
+  run(): void {
+    const gatewayIp = getDockerGatewayIp();
+
+    // Dynamic config: middleware + service definitions
+    const dynamicConfig = `# Trafic: Forward auth middleware definition
+http:
+  middlewares:
+    trafic-auth:
+      forwardAuth:
+        address: "http://${gatewayIp}:9876/__auth__"
+        authResponseHeaders:
+          - "X-Trafic-Project"
+
+    trafic-errors:
+      errors:
+        status:
+          - "502"
+          - "503"
+        service: trafic-service
+        query: "/"
+
+  services:
+    trafic-service:
+      loadBalancer:
+        servers:
+          - url: "http://${gatewayIp}:9876"
+`;
+
+    exec("mkdir -p /home/ddev/.ddev/traefik/custom-global-config", { silent: true });
+    writeFileSync("/home/ddev/.ddev/traefik/trafic.yaml", dynamicConfig);
+    writeFileSync("/home/ddev/.ddev/traefik/custom-global-config/trafic.yaml", dynamicConfig);
+    exec("chown -R ddev:ddev /home/ddev/.ddev/traefik", { silent: true });
+
+    // Static config: attach middleware to entry points
+    const staticConfig = `entryPoints:
+  http-80:
+    http:
+      middlewares:
+        - trafic-auth@file
+        - trafic-errors@file
+  http-443:
+    http:
+      middlewares:
+        - trafic-auth@file
+        - trafic-errors@file
+`;
+
+    writeFileSync("/home/ddev/.ddev/traefik/static_config.trafic.yaml", staticConfig);
+    exec("chown ddev:ddev /home/ddev/.ddev/traefik/static_config.trafic.yaml", { silent: true });
+
+    // Remove the old catch-all router config — it's superseded by entry point middleware
+    const oldDynamicYaml = "/home/ddev/.ddev/traefik/dynamic.yaml";
+    if (existsSync(oldDynamicYaml)) {
+      rmSync(oldDynamicYaml);
+    }
+
+    // Restart DDEV router to apply the new static config
+    exec("su - ddev -c 'DDEV_NONINTERACTIVE=true ddev poweroff && ddev start --all'", {
+      silent: false,
+    });
+  },
+};

--- a/packages/trafic-agent/src/setup/migrations/index.ts
+++ b/packages/trafic-agent/src/setup/migrations/index.ts
@@ -7,6 +7,7 @@ import { migration0004DdevHostnameSudoers } from "./0004__ddev_hostname_sudoers.
 import { migration0005TraefikGatewayIp } from "./0005__traefik_gateway_ip.js";
 import { migration0006TraefikGatewayIpFix } from "./0006__traefik_gateway_ip_fix.js";
 import { migration0007UfwDockerTraficPort } from "./0007__ufw_docker_trafic_port.js";
+import { migration0008TraefikEntrypointMiddleware } from "./0008__traefik_entrypoint_middleware.js";
 
 /** Path to the persisted migration state file */
 export const MIGRATIONS_STATE_FILE = "/etc/trafic/.migrations.json";
@@ -20,6 +21,7 @@ export const ALL_MIGRATIONS: Migration[] = [
   migration0005TraefikGatewayIp,
   migration0006TraefikGatewayIpFix,
   migration0007UfwDockerTraficPort,
+  migration0008TraefikEntrypointMiddleware,
 ];
 
 // ---------------------------------------------------------------------------

--- a/packages/trafic-agent/src/utils/config.ts
+++ b/packages/trafic-agent/src/utils/config.ts
@@ -77,6 +77,22 @@ export function loadConfig(configPath?: string): AgentConfig {
   };
 }
 
+/**
+ * Parse basic_auth entries from TOML.
+ * Accepts either plain strings ("user:pass") or objects ({username, password}).
+ */
+function parseBasicAuthEntries(raw: unknown): string[] | null {
+  if (!Array.isArray(raw)) return null;
+  return raw.map((entry) => {
+    if (typeof entry === "string") return entry;
+    if (typeof entry === "object" && entry !== null) {
+      const { username, password } = entry as Record<string, unknown>;
+      return `${username}:${password}`;
+    }
+    return String(entry);
+  });
+}
+
 function mergeAuthConfig(raw?: Record<string, unknown>): AuthConfig {
   if (!raw) return DEFAULT_CONFIG.auth;
 
@@ -89,7 +105,7 @@ function mergeAuthConfig(raw?: Record<string, unknown>): AuthConfig {
     allowedIps:
       (raw.allowed_ips as string[]) ?? DEFAULT_CONFIG.auth.allowedIps,
     tokens: (raw.tokens as string[]) ?? DEFAULT_CONFIG.auth.tokens,
-    basicAuth: (raw.basic_auth as string[]) ?? DEFAULT_CONFIG.auth.basicAuth,
+    basicAuth: parseBasicAuthEntries(raw.basic_auth) ?? DEFAULT_CONFIG.auth.basicAuth,
     rules: rules.map(
       (r): AuthRule => ({
         match: r.match as string,


### PR DESCRIPTION
## Problems

### 1. Auth bypass — catch-all router doesn't work

The previous approach used a low-priority catch-all Traefik router (`priority=1`) with `trafic-auth` middleware. This never worked because DDEV's project-specific routers always win — they have higher implicit priority and no `trafic-auth` middleware attached. All requests passed through unauthenticated.

### 2. Basic auth always fails

`basic_auth = [{username = "trafic", password = "demo"}]` in TOML is parsed as an array of objects, but `checkAuth()` compared credentials as `"user:pass"` strings via `Array.includes()`. This always returned false.

## Fixes

### Traefik: entry point-level middleware

The correct approach (used in trafic v1 with DDEV 1.24) is to attach `trafic-auth@file` and `trafic-errors@file` at the **entry point level** via `static_config.trafic.yaml`. DDEV merges all `static_config.*.yaml` files into `.static_config.yaml` on every start — every request on `http-80` and `http-443` then goes through auth regardless of which project router handles it.

Dynamic middleware config is also written to `custom-global-config/` (DDEV 1.25+ survives config dir purge on restart).

Migration `0008` applies the change on existing servers: writes the new files, removes the old `dynamic.yaml`, and restarts DDEV.

### Basic auth: normalize TOML objects to strings

Added `parseBasicAuthEntries()` in config loader to convert `{username, password}` objects to `"username:password"` strings at load time. Both formats are accepted.